### PR TITLE
feat(table): add alignment support

### DIFF
--- a/src/elements/Table.test.tsx
+++ b/src/elements/Table.test.tsx
@@ -1,7 +1,7 @@
 /* @jsx MD */
 import MD, { render, Text } from "..";
 
-import { Table } from ".";
+import { Table, TableAlignment } from ".";
 
 describe("Table", () => {
   it("returns the table in Markdown from text", () => {
@@ -50,6 +50,43 @@ describe("Table", () => {
     expect(render(<Table headers={headers} body={body} />)).toBe(`
 | Foo header | Bar header |
 | ----- | ----- |
+| Foo body 1 | Bar body 1 |
+| Foo body 2 | Bar body 2 |
+`);
+  });
+
+  it("returns the table in Markdown from text with partial alignment", () => {
+    const headers = {
+      foo: "Foo header",
+      bar: {
+        title: "Bar header",
+        alignment: TableAlignment.RIGHT,
+      },
+    };
+    const body = [
+      { foo: "Foo body 1", bar: "Bar body 1" },
+      { foo: "Foo body 2", bar: "Bar body 2" },
+    ];
+    expect(render(<Table headers={headers} body={body} />)).toBe(`
+| Foo header | Bar header |
+| ---------- | ---------: |
+| Foo body 1 | Bar body 1 |
+| Foo body 2 | Bar body 2 |
+`);
+  });
+
+  it("returns the table in Markdown from text with short component headers and alignment", () => {
+    const headers = {
+      foo: { title: <Text>F</Text>, alignment: TableAlignment.CENTER },
+      bar: { title: <Text>B</Text>, alignment: TableAlignment.LEFT },
+    };
+    const body = [
+      { foo: "Foo body 1", bar: "Bar body 1" },
+      { foo: "Foo body 2", bar: "Bar body 2" },
+    ];
+    expect(render(<Table headers={headers} body={body} />)).toBe(`
+| F | B |
+| :---: | :---- |
 | Foo body 1 | Bar body 1 |
 | Foo body 2 | Bar body 2 |
 `);

--- a/src/elements/Table.tsx
+++ b/src/elements/Table.tsx
@@ -2,10 +2,34 @@
 import MD, { Component, Fragment, MarkdownChildren, MarkdownElement } from "..";
 import { intersperse } from "../util/intersperse";
 
+export enum TableAlignment {
+  LEFT = "left",
+  CENTER = "center",
+  RIGHT = "right",
+}
+
+/** @internal */
+interface TableColumn {
+  width: number;
+  alignment?: TableAlignment;
+}
+
+/** @internal */
+interface TableHeader {
+  title: MarkdownChildren;
+  alignment?: TableAlignment;
+}
+
 /** @internal */
 interface Props<Headers extends string> {
   body: Record<Headers, MarkdownChildren>[];
-  headers: Record<Headers, MarkdownChildren>;
+  headers: Record<Headers, MarkdownChildren | TableHeader>;
+}
+
+/** @internal */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isTableHeader(value: any): value is TableHeader {
+  return value && value.title;
 }
 
 /** @internal */
@@ -24,9 +48,20 @@ function renderRow(entries: Record<string, MarkdownChildren>): MarkdownElement {
 }
 
 /** @internal */
-function renderSeparator(columnWidths: number[]): string {
-  return columnWidths
-    .map((width: number) => ` ${"-".repeat(width)} |`)
+function renderSeparator(columns: TableColumn[]): string {
+  return columns
+    .map((column: TableColumn) => {
+      switch (column.alignment) {
+        case TableAlignment.LEFT:
+          return ` :${"-".repeat(Math.max(column.width - 1, 2))} |`;
+        case TableAlignment.CENTER:
+          return ` :${"-".repeat(Math.max(column.width - 2, 1))}: |`;
+        case TableAlignment.RIGHT:
+          return ` ${"-".repeat(Math.max(column.width - 1, 2))}: |`;
+        default:
+          return ` ${"-".repeat(Math.max(column.width, 3))} |`;
+      }
+    })
     .join("");
 }
 
@@ -54,23 +89,24 @@ function sortKeysInOrderOf<Obj extends Record<string, unknown>>(
  *   ```js
  *   const headers = {
  *     foo: "Foo header",
- *     bar: "Bar header",
+ *     bar: { title: "Bar header", alignment: TableAlignment.CENTER },
+ *     baz: { title: "Baz header" },
  *   };
  *   const body = [
- *     { foo: "Foo body 1", bar: "Bar body 1" },
- *     { foo: "Foo body 2", bar: "Bar body 2" },
+ *     { foo: "Foo body 1", bar: "Bar body 1", baz: "Baz body 1" },
+ *     { foo: "Foo body 2", bar: "Bar body 2", baz: "Baz body 2" },
  *   ];
  *   render(<Table headers={headers} body={body} />)
  *   ===
  *   `
- *   | Foo header | Bar header |
- *   | ---------- | ---------- |
- *   | Foo body 1 | Bar body 1 |
- *   | Foo body 2 | Bar body 2 |
+ *   | Foo header | Bar header | Baz header |
+ *   | ---------- | :--------: | ---------- |
+ *   | Foo body 1 | Bar body 1 | Baz body 1 |
+ *   | Foo body 2 | Bar body 2 | Baz body 2 |
  *   `
  */
 export function Table<Headers extends string>({
-  /** An array of data objects with the same keys as the headers to be displayed as rows */
+  /** An array of data objects with the same keys as the headers to be displayed as rows. */
   body,
   /**
    * An object giving the headers for each column. The order in which the keys
@@ -79,12 +115,28 @@ export function Table<Headers extends string>({
    */
   headers,
 }: Props<Headers>): ReturnType<Component<Props<Headers>>> {
-  const columnWidths = Object.values(headers).map((header) => {
-    if (typeof header !== "string") {
-      return 5;
+  const columns = Object.values(headers).map((header) => {
+    let width = typeof header !== "string" ? 5 : header.length;
+    let alignment;
+    if (isTableHeader(header)) {
+      ({ alignment } = header);
+      if (typeof header.title === "string") {
+        width = header.title.length;
+      }
     }
-    return header.length;
+    return { width, alignment };
   });
+
+  const normalizedColumns = Object.keys(headers).reduce(
+    (normalizedHeaderAccumulator: Record<string, MarkdownChildren>, key) => {
+      const header = headers[key as Headers];
+      return {
+        ...normalizedHeaderAccumulator,
+        [key]: isTableHeader(header) ? header.title : header,
+      } as Record<string, MarkdownChildren>;
+    },
+    {}
+  );
 
   const sortedBody = body.map(
     sortKeysInOrderOf(Object.keys(headers) as Headers[])
@@ -92,9 +144,9 @@ export function Table<Headers extends string>({
   return (
     <Fragment>
       {"\n|"}
-      {renderRow(headers)}
+      {renderRow(normalizedColumns)}
       {"\n|"}
-      {renderSeparator(columnWidths)}
+      {renderSeparator(columns)}
       {"\n|"}
       {intersperse(
         sortedBody.map((row) => renderRow(row)),

--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -17,7 +17,7 @@ export { Strikethrough } from "./Strikethrough";
 export { Reference } from "./Reference";
 export { ReferenceImage } from "./ReferenceImage";
 export { ReferenceLink } from "./ReferenceLink";
-export { Table } from "./Table";
+export { Table, TableAlignment } from "./Table";
 export { Task } from "./Task";
 export { Text } from "./Text";
 export { UnorderedList } from "./UnorderedList";


### PR DESCRIPTION
Closes #3.

The `Math.max` for the separator width is to ensure that at least three dash `-` will be rendered.

Let me know what do you think !